### PR TITLE
Changes for service request creation API simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,24 @@ Scripts for provisioning and benchmarking clamp core performance
 
 * brew install scala@2.12
 
+## Running Clamp
+Clamp and its dependencies can be run with the following Docker Compose command
+
+```bash
+$ docker-compose -d up
+```
+
 ## Running Tests
 
 ```bash
-$ cd benchmarking
-$ mvn gatling:test -DgatlingSimulationClass=clampcore.{simulation-class-name}
+$ mvn gatling:test -DgatlingSimulationClass=clampcore.{simulation-class-name} -D{arg-name}={arg-value}
 ```
 
 **Simulation Classes**
 - `InitiateWorkflowSimulation` - Tests workflow creation, service request creation and service status polling APIs
 - `CreateServiceRequestSimulation` - Tests service request creation API
+
+**Example**
+```bash
+$ mvn gatling:test -DgatlingSimulationClass=clampcore.CreateServiceRequestSimulation -DmaxRPS=500 -DdurationSeconds=120 -DmaxDurationSeconds=300
+```

--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@ Scripts for provisioning and benchmarking clamp core performance
 
 * brew install scala@2.12
 
+## Running Tests
+
+```bash
+$ cd benchmarking
+$ mvn gatling:test -DgatlingSimulationClass=clampcore.{simulation-class-name}
+```
+
+**Simulation Classes**
+- `InitiateWorkflowSimulation` - Tests workflow creation, service request creation and service status polling APIs
+- `CreateServiceRequestSimulation` - Tests service request creation API

--- a/benchmarking/pom.xml
+++ b/benchmarking/pom.xml
@@ -70,7 +70,7 @@
             <jvmArg>-DdurationMaxMinutes=${durationMaxSeconds}</jvmArg>
             <jvmArg>-Xmx5g</jvmArg>
           </jvmArgs>
-          <simulationClass>clampcore.InitiateWorkflowSimulation</simulationClass>
+          <simulationClass>${gatlingSimulationClass}</simulationClass>
           <propagateSystemProperties>true</propagateSystemProperties>
         </configuration>
       </plugin>

--- a/benchmarking/src/test/scala/clampcore/CreateServiceRequestSimulation.scala
+++ b/benchmarking/src/test/scala/clampcore/CreateServiceRequestSimulation.scala
@@ -80,7 +80,7 @@ class CreateServiceRequestSimulation extends Simulation {
       .protocols(baseHttp),
 
       createPollServiceRequestScenario.inject(
-        nothingFor(1 second), // needed for Clamp complete workflow creation
+        nothingFor(1 second), // needed for Clamp to complete workflow creation
         rampUsersPerSec(1).to(MAX_RPS).during(DURATION_SECONDS seconds)
       )
       .protocols(baseHttp)

--- a/benchmarking/src/test/scala/clampcore/CreateServiceRequestSimulation.scala
+++ b/benchmarking/src/test/scala/clampcore/CreateServiceRequestSimulation.scala
@@ -77,13 +77,13 @@ class CreateServiceRequestSimulation extends Simulation {
       createWorkflowScenario.inject(
         atOnceUsers(1)
       )
-      .protocols(baseHttp),
-
-      createPollServiceRequestScenario.inject(
-        nothingFor(1 second), // needed for Clamp to complete workflow creation
-        rampUsersPerSec(1).to(MAX_RPS).during(DURATION_SECONDS seconds)
-      )
       .protocols(baseHttp)
+      .andThen(
+        createPollServiceRequestScenario.inject(
+          rampUsersPerSec(1).to(MAX_RPS).during(DURATION_SECONDS seconds)
+        )
+        .protocols(baseHttp)
+      )
     )
   )
   .maxDuration(MAX_DURATION_SECONDS seconds)

--- a/benchmarking/src/test/scala/clampcore/CreateServiceRequestSimulation.scala
+++ b/benchmarking/src/test/scala/clampcore/CreateServiceRequestSimulation.scala
@@ -12,6 +12,9 @@ import scala.language.postfixOps
 class CreateServiceRequestSimulation extends Simulation {
 
   var logger: Logger = LoggerFactory.getLogger("SimulationLogger")
+  val MAX_RPS = Integer.getInteger("maxRPS", 500).toDouble
+  val DURATION_SECONDS = Integer.getInteger("durationSeconds", 120).toInt
+  val MAX_DURATION_SECONDS = Integer.getInteger("maxDurationSeconds", 300).toInt
 
   var workflowName = ""
 
@@ -77,11 +80,11 @@ class CreateServiceRequestSimulation extends Simulation {
       .protocols(baseHttp),
 
       createPollServiceRequestScenario.inject(
-        nothingFor(1 second),
-        rampUsersPerSec(1).to(500).during(1 minute)
+        nothingFor(1 second), // needed for Clamp complete workflow creation
+        rampUsersPerSec(1).to(MAX_RPS).during(DURATION_SECONDS seconds)
       )
       .protocols(baseHttp)
     )
   )
-  .maxDuration(5 minutes)
+  .maxDuration(MAX_DURATION_SECONDS seconds)
 }

--- a/benchmarking/src/test/scala/clampcore/CreateServiceRequestSimulation.scala
+++ b/benchmarking/src/test/scala/clampcore/CreateServiceRequestSimulation.scala
@@ -1,0 +1,87 @@
+package clampcore
+
+import io.gatling.core.Predef._
+import io.gatling.core.feeder.Feeder
+import io.gatling.http.Predef._
+import org.slf4j.{Logger, LoggerFactory}
+
+import java.util.UUID
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+class CreateServiceRequestSimulation extends Simulation {
+
+  var logger: Logger = LoggerFactory.getLogger("SimulationLogger")
+
+  var workflowName = ""
+
+  val workflowDefinition =
+    """
+      {
+        "name": "${workflow_name}",
+        "description": "a benchmarking flow with only http sync services",
+        "steps": [
+          {
+            "name": "benchmarking step one",
+            "mode": "HTTP",
+            "val": {
+              "method": "GET",
+              "url": "http://api-server:8083/api/step1"
+            }
+          }
+        ]
+      }
+      """
+
+  val baseHttp = http
+    .baseUrl("http://localhost:8080")
+    .header("no-cache", "no-cache")
+    .contentTypeHeader("application/json")
+    .userAgentHeader("PostmanRuntime/7.26.8")
+    .acceptHeader("*/*")
+    .connectionHeader("keep-alive")
+
+  val uuidfeeder: Feeder[String] = Iterator.continually(Map("workflow_name" -> UUID.randomUUID().toString))
+
+  def createWorkflow() = {
+    exec(http("create_workflow")
+      .post("/workflow")
+      .body(StringBody(workflowDefinition)).asJson
+      .check(jsonPath("$.name").saveAs("workflowName"))
+    )
+  }
+
+  def createServiceRequest() = {
+    http("execute_workflow")
+      .post("/serviceRequest/${workflow_name}")
+      .check(status.is(200))
+  }
+
+  var createWorkflowScenario = scenario("Create workflow scenario")
+    .feed(uuidfeeder)
+    .exec(createWorkflow())
+    .exec(session => {
+      workflowName = session("workflowName").as[String]
+      session
+    })
+
+  var createPollServiceRequestScenario = scenario("Create service request scenario")
+    .exec(_.set("workflow_name", workflowName))
+    .exec(createServiceRequest())
+
+  setUp(
+    List(
+      createWorkflowScenario.inject(
+        atOnceUsers(1)
+      )
+      .protocols(baseHttp),
+
+      createPollServiceRequestScenario.inject(
+        nothingFor(1 second),
+        rampUsersPerSec(1).to(500).during(1 minute)
+      )
+      .protocols(baseHttp)
+    )
+  )
+  .maxDuration(5 minutes)
+}


### PR DESCRIPTION
The changeset implements simulation for Clamp's service request creation API.

The simulation creates a new workflow with a random name and calls service request creation API as many times as it can up to 500 calls.